### PR TITLE
fix: Increase and decrease dice properly

### DIFF
--- a/lib/yzur.js
+++ b/lib/yzur.js
@@ -691,18 +691,26 @@ export class YearZeroRoll extends Roll {
         const currentRangeIndex = dieTypes.indexOf(die);
         let newDie;
         if (currentRangeIndex >= 0) {
+          var temp_mod = 0;
+          // Increase or decrease just by one and modify `mod` accordingly 
+          if (mod > 0) {
+            temp_mod = 1;
+            mod--;
+          } else {
+            temp_mod = -1;
+            mod++;
+          }
           const maxRangeIndex = dieTypes.length - 1;
-          const rangeIndex = currentRangeIndex + mod;
+          const rangeIndex = currentRangeIndex + temp_mod;
           const newRangeIndex = Math.clamped(rangeIndex, 0, maxRangeIndex);
           newDie = dieTypes[newRangeIndex];
-          mod -= (newRangeIndex - currentRangeIndex);
           dice[die]--;
           dice[newDie]++;
         }
 
         // Positive excess mod means adding an extra die.
         // Note: the pool can only have a maximum of 2 dice.
-        if (mod > 0) {
+        if (newDie === 'a' && mod > 0) {
           if (n < 2) {
             const ex = Math.min(dieTypes.length, mod);
             dice[dieTypes[ex - 1]]++;
@@ -716,7 +724,7 @@ export class YearZeroRoll extends Roll {
         }
         // Negative excess mod means removing the die and decreasing another one.
         // Note: The pool has always 1 die.
-        else if (mod < 0 && n > 1) {
+        else if (newDie === 'd' && mod < 0 && n > 1) {
           dice[newDie]--;
           // We add 1 because we removed one die (which is 1 step).
           mod++;

--- a/lib/yzur.js
+++ b/lib/yzur.js
@@ -664,12 +664,22 @@ export class YearZeroRoll extends Roll {
         if (mod > 0) {
           if (n > 2) break;
           if (pool.filter(t => t === 'a').length >= 2) break;
+          if (n === 1) {
+            dice.d += 1;
+            mod--;
+            if (mod === 0) break;
+            pool.push('d');
+          }
         }
         else if (n === 0) {
           dice.d = 1;
           break;
         }
         else if (n === 1 && pool.includes('d')) {
+          break;
+        }
+        else if (n === 2 && pool.filter(t => t === 'd').length >= 2) {
+          dice.d = 1;
           break;
         }
 
@@ -706,28 +716,6 @@ export class YearZeroRoll extends Roll {
           newDie = dieTypes[newRangeIndex];
           dice[die]--;
           dice[newDie]++;
-        }
-
-        // Positive excess mod means adding an extra die.
-        // Note: the pool can only have a maximum of 2 dice.
-        if (newDie === 'a' && mod > 0) {
-          if (n < 2) {
-            const ex = Math.min(dieTypes.length, mod);
-            dice[dieTypes[ex - 1]]++;
-            if (mod > ex) mod -= ex;
-            else break;
-          }
-          else {
-            const diceBelowMaxRange = Object.entries(dice).filter(([k, v]) => v > 0 && k > 'a').length;
-            if (diceBelowMaxRange <= 0) break;
-          }
-        }
-        // Negative excess mod means removing the die and decreasing another one.
-        // Note: The pool has always 1 die.
-        else if (newDie === 'd' && mod < 0 && n > 1) {
-          dice[newDie]--;
-          // We add 1 because we removed one die (which is 1 step).
-          mod++;
         }
       }
       // MUTANT YEAR ZERO & FORBIDDEN LANDS

--- a/lib/yzur.js
+++ b/lib/yzur.js
@@ -665,7 +665,12 @@ export class YearZeroRoll extends Roll {
           if (n > 2) break;
           if (pool.filter(t => t === 'a').length >= 2) break;
           if (n === 1) {
-            dice.d += 1;
+            if (dice.d >= 0) {
+              dice.d += 1;
+            }
+            else {
+              dice.d = 1;
+            }
             mod--;
             if (mod === 0) break;
             pool.push('d');


### PR DESCRIPTION
## Summary
<!-- Here goes a short summary about what the PR is about. -->

Dice should increase or decrease one by one in balanced matter. When increasing the smaller die should increase first. When decreasing the bigger die should decrease first. In both cases modified only by 1. If increasing or decreasing by more than 1, after every increase/decrease we should choose new die to increase/decrease. We should never increase/decrease only one of the dice by multiple dice types.

For example:
D10 and D8 with modifier -2 should decrease D10 to D8 and then either D8s to D6. Final result should be D8 and D6.
Same dice with modifier -3, should decrease D10 to D8, then D8 to D6 and then second D8 also to D6. Final result should be D6 and D6.
Same for increase, D10 and D8 with +3 should upgrade D8 to D10, then to D12 and second D10 to D12, resulting in two D12s.

Now, after the changes, the main loop will find new die to modify after every increase or decrease of die accordingly to the rules.

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->
### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes (wiki).