### PR TITLE
fix: add missing die

### DIFF
--- a/lib/yzur.js
+++ b/lib/yzur.js
@@ -1289,10 +1289,14 @@ class YearZeroRoll extends Roll {
       // 1 — Modifies the dice ranges.
       while (mod !== 0) {
         let i;
-        // 1.1.1 — A positive modifier increases the lowest term.
+        // 1.1.1 — A positive modifier increases the lowest term or add second die.
         if (mod > 0) {
           i = dice.indexOf(Math.min(...dice));
-          dice[i] = refactorRange(dice[i], 1);
+          if (dice.length < 2) {
+            dice.push(diceMap[1]);
+          } else {
+            dice[i] = refactorRange(dice[i], 1);
+          }
           mod--;
         }
         // 1.1.2 — A negative modifier decreases the highest term.

--- a/lib/yzur.js
+++ b/lib/yzur.js
@@ -1294,7 +1294,8 @@ class YearZeroRoll extends Roll {
           i = dice.indexOf(Math.min(...dice));
           if (dice.length < 2) {
             dice.push(diceMap[1]);
-          } else {
+          }
+          else {
             dice[i] = refactorRange(dice[i], 1);
           }
           mod--;


### PR DESCRIPTION
## Summary
<!-- Here goes a short summary about what the PR is about. -->

Right now when one die is in the pool (D6, D8, D10 or D12) and modifier is positive (1+), then just one die is upgraded on every iteration but instead it should add second die and then iterate and upgrade lowest of the two.

My pull request fixes this behavior.

If there is just one die and roll modifier is +1 or higher, then always should add another die to the pool to create two dice pool. So, whenever `mod` is > 0 and we have one die we should just add another D6 die and decrease `mod` by 1. If there are two dice and `mod` is positive, then proceed normally.

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->
### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes (wiki).