### PR TITLE
Fix: Shortened "Ammunitionsbälte"

### DIFF
--- a/lang/sv.json
+++ b/lang/sv.json
@@ -95,7 +95,7 @@
   "T2K4E.ItemPropNames.twoHanded": "Tvåhandad",
   "T2K4E.ItemPropNames.mounted": "Monterad",
   "T2K4E.ItemPropNames.disposable": "Engångs",
-  "T2K4E.ItemPropNames.ammoBelt": "Ammunitionsbälte",
+  "T2K4E.ItemPropNames.ammoBelt": "Ammobälte",
   "T2K4E.ItemPropNames.magazine": "Är Magasin",
   "T2K4E.ItemPropNames.armored": "Bepansrad",
   "T2K4E.ItemPropNames.bipod": "Tvåbensstativ",


### PR DESCRIPTION
Fix: The translated word "Ammunitionsbälte" was too long for the column presented on the weapon sheet, so it jumped down over the option below and made both unreadable.
The new translation is "Ammobälte", which fits in the column.

## Summary
The translated word "Ammunitionsbälte" was too long for the column presented on the weapon sheet, so it jumped down over the option below and made both unreadable.
The new translation is "Ammobälte", which fits in the column.

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->
### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [X] This PR is not a code change (e.g. documentation, README, ...)
### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes (wiki).